### PR TITLE
Start Lilium License Draft

### DIFF
--- a/src/rfcs/0012-lilium-license.md
+++ b/src/rfcs/0012-lilium-license.md
@@ -1,0 +1,229 @@
+# RFC Template
+
+## Summary
+
+The Lilium License is a permissive license that provides copyright, patent, and limited trademark grants, as well as a clause about Technological Protection Measures. It is intended to comply with the Open Source License definition defined by the Open Source Institute. It is also intended to comply with the four freedoms of free software set forth by the Free Software Foundation, though it does not create a copyleft obligation like many licenses provided by the FSF.
+
+## Motivation
+
+Certain future design features
+
+## Informative Explanation
+
+<!--Provide an informative explanation of proposal. 
+This is intended to be read by someone who wishes to understand the proposal but may not have advanced technical background.
+This section is intended for:
+* People using the Lilium Operating System as a Software Developer
+* People looking to understand the Lilium Operating System
+* People looking to understand the Lilium Project as a whole
+
+This section is not normative-->
+
+## Normative Text
+
+### License Text
+
+Copyright (C) &lt;year&gt; &lt;name(s)&gt;
+
+#### Definitions
+
+"This Software" shall mean the Computer Program to which this license is applied or any part thereof, and for greater certainty, includes any non-Computer Program work that is included as part of the Computer Program.
+
+"Modified Version" shall mean a Computer Program which is a derivative work of This Software that contains a substantial portion of this Computer Program and any additional programming code which have a non-trivial impact on behaviour, and shall include such a derivative of a Modified Version or a Software Port.
+
+"Software Port" shall mean a Computer Program which is a derivative work of This Software or a Modified Version that is prepared solely for the purposes of making This Software or that Modified Version interoperable with any other software, computer system, or technology.
+
+"This License" shall mean the Lilium License Version 1.
+
+"The Attribution Notice" shall mean the line following the License header, and preceeding the definitions section that begins with the word "Copyright", followed by the (C) symbol, and for greater certainty, shall include the entire line.
+
+"Entire License Notice" shall mean the complete, unmodified text of This License, including The Attribution Notice.
+
+"Source Form" shall mean the form of the software which is the preferred form for editing, which may be translated by a computer program or sequence of computer programs into program code that can be readily executed by a computer system.
+
+"Binary Form" shall mean any form of the software that is not Source Form, and includes, but is not limited to, the form of the software which may be readily executed by a computer system.
+
+"Contribution" shall mean a work, other than a work subject to the public domain, which is submitted by the owner of the work or any person authorized to do so for inclusion in This Software by the Copyright holder, or for inclusion in a derivative work of This Software by the maintainer thereof, and shall include contributions made by way of the git or other version control software, Pull or Merge Requests, or by electronic mail or other telecommunication where the Contribution is delineated as such, and, for greater certainty, includes an aggregate of such Contributions submitted as a single Contribtuion.
+
+"Contributor" shall mean any person other than a Copyright Holder, who submits a Contribution for inclusion in This Software.
+
+"Non-infringing Use", as applied to a work subject to copyright, shall mean any act that, in respect to the Copyright Laws in the jurisdiction in which the act is performed, is expressly authorized thereby despite the exclusive Copyrights and/or Moral Rights afforded by such law to the authors of that work, but does not include any use that is not infringing by reason of authorization by the copyright holder.
+
+
+"Software Subject to the Lilium License" shall mean any software which is used under the terms of This License, or any version of the Lilium License, or any software that is published by the copyright holders or a person with the authority of the copyright holders under any of the following, whether or not it is actually used under the terms of This License:
+    * This License or any version or versions of the Lilium License, potentially combined with any other license, or
+    * This License or any version or versions of the Lilium License, as an optional alternative to any other license or licenses.
+
+For greater certainty, Software Subject to the Lilium License includes, but is not limited to, This Software.
+
+#### §1 Copyright License
+
+Everyone who receives a copy of this work, whether in source form, or in binary form, shall recieve perpetual, worldwide, royalty free, non-exclusive, sublicenseable permission to copy, distribute, publish, prepare derivative works including, but not limited to, Modified Versions of the software, and to perform the software either publically or privately (collectively "use"), and may do so in gratis or for a fee, provided that, for any use other than a non-infringing use:
+
+* In respect to any use of this work, except for copying the work for personal use, including backup or archival use, where such copy is not disseminated, either:
+    * This Entire License Notice shall be maintained and/or reproduced alongside that use, or
+    * A specified Short-form License Notice shall be reproduced alongside that use, including the above Attribution Information, and a link to obtain a copy of this Entire License Notice, and
+* The additional condition on distribution specified in §4 is upheld by any such distribution.
+
+#### §2 Patent License
+
+Everyone who receives a copy of this work shall have from the Copyright Holders and each Contributor a perpetual, worldwide, royalty free, non-exclusive, patent license to make, have made, use, offer to sell, sell, import, or otherwise do any thing that would be, but for this section, an infringement of any patent held by the any Copyright Holder or Copyright Holders or by any Contributor or Contributors, or held by both, with respect to such claims as may be licenseable by such a Contributor or a Copyright Holder which would necessarily be infringed by:
+
+  * Their Contributions Alone, or
+  * The Combination of their Contribution and the Work at the time the Contribution was actually included in the work.
+
+The above Patent License shall be revoked to a particular person or persons on such a day that the person may file, in any court worldwide, a suit against the any Copyright Holder or Copyright Holders, against any Contributor or Contributors, or against any Copyright Holder or Copyright Holders together with any Contributor or Contributors, alleging that this Work or any Contribution or combination of Contributions thereof, infringes any patent they have rights to. 
+
+#### §3 Limited Trademark License
+
+Everyone who distributes a copy of this software shall have a limited license in respect to any trademarks held by the Copyright Holders or by any Contributor, to use those marks, where such use is necessary to:
+* Reproduce or distribute this Entire License Notice or a Short-form License Notice, including the Attribution Information above, or to otherwise fulfill the conditions of this license,
+* Accurately identify the origin of this software, 
+* To distribute the unmodified software or any contribution made thereto, or
+* To distribute the unmodified software together with any other work licensed by the Copyright Holders or the particular Contributor under this License.
+
+Except as provided for explicitly above, this license shall not be taken to convey any right, privilege, or permission to use any Trademark held by the Copyright Holders or any Contributors, including Trademarks used in connection with this software.
+
+#### §4 Technological Protection Measure
+
+For the purposes of this section, to "remove" a Technological Protection Measure ("TPM") shall mean to, with respect to that TPM, perform any action that would constitute circumventing that TPM if done without the authority of the holder of the appropriate Copyright, within the meaning of:
+
+* s. 41 of the Copyright Act (R.S.C., 1985, c. C-42) established by the Parliament of Canada, or
+* Any equivalent or similar section or provision of the copyright laws in the jurisdiction in which any of the acts permitted below are performed.
+
+You shall be granted permission to remove any Technological Protection Measure, where the removal of the Technological Protection Measure is necessarily performed or necessarily consequential in doing any of the following:
+
+* Copying This Software, as authorized by This License or any other license or permission applied to This Software,
+* Modifying the copy of This Software,
+* Replacing the copy of This Software with any other copy of This Software, any Modified Version, or any Software Port,
+* Replacing the copy of This Software on the system or device with any other software, 
+* Combining This Software with any other Software where the use of that other Software does not infringe any copyright,
+* Using This Software with any other Software where the use of that other Software does not infringe any copyright,
+* Making This Software interoperable with any other software, system, or device,
+* Doing any reasonable thing necessary to repair This Software or any software that replaces This Software on a system or device, or to repair the system or device on which the system is distributed, or
+* Making any non-infringing use of the software, including creating a backup or archival copy of the software, or to make a use that constitutes Fair Use or Fair Dealing (as the case may be) or any other similar applicable exception to copyright.
+
+Additionally, You have permission to produce, distribute, sell, import, export, advertise, and offer to sell (collectively "deal in") any software or device designed to remove a Technological Protection Measure, or deal in such a software or device which is dealt in for the primary or substantial purpose of doing so, where the manner of removal is necessary and/or consequential in the doing of any thing listed above, whether or not that software or device may also be used to remove such a Technological Protection Measure for any other purpose, including purposes not authorized by this license.
+
+The above applies to any Technological Protection Measure which:
+
+* Controls Access to This Software, any Modified Version, or any Software Port, whether or not it also controls access to any other work,
+* Operates in such a way that removal or Modification of This Software, or This Software combined with any other Software Subject to the Lilium License, would constitute removal of the Technological Protection Measure.
+
+(collectively "Covered Technological Protection Measures")
+
+If You distribute This Software, a Modified Version, or a Software Port together with any other work, whether or not subject to this License, or together with any system or device, You agree to provide to any person to whom This Software is distributed together with that software or with that system or device and who accepts the terms of this license in respect to This Software, the Modified Version, or the Software Port, the permissions set forth in this section in respect to a Covered Technological Protection Measure that controls access to a work that You hold copyright for.  
+For greater certainty, this license does not create any further obligation upon You to aid any person in carrying out an act allowed by this section, nor to license or permit any other act that would otherwise constitute an infringement of your copyrights, or other intellectual property rights, in respect to that other work, or that system or device.
+
+#### §5 No Additional Rights; No Additional Restrictions
+
+Nothing in this license shall be taken to convey any right, privilege, or permission, whether by estoppal or otherwise, between the licensor and licensee, other than such rights and permission that are expressly conveyed above by it.
+
+Nothing in this license shall be taken as a waiver, assignment, or permission to infringe any moral right held by any person in connection with This Software.
+
+Nothing in this license shall be taken to abrogate, restrain, or prohibit any non-infringing use of this work authorized by applicable law, such as Fair Use or Fair Dealing (as applicable).
+
+#### §6 Short Form Notice
+
+Any person who distributes This Software may, at their option, reproduce The Attribution Notice along with the following notice instead of this Entire License Notice:
+> Everyone who recieves a copy of this software may copy, distribute, publish, prepare derivative works, and to use the software in public or private performance (collectively "use"), where such use shall be governed by the terms of the Lilium License, Version 1.
+>
+> A copy of the full text Lilium License, Version 1 may be obtained at TODO INSERT ADDRESS.
+> 
+> TO THE GREATEST EXTENT POSSIBLE BY LAW, THIS SOFTWARE IS PROVIDED ON AN AS IS BASIS, WITHOUT ANY WARRANTY, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. 
+
+If, with the permission of the copyright holder, This Software may be distributed under the terms of this license or any later version, they may instead apply the future-version Short-Form License Notice:
+> Everyone who recieves a copy of this software may copy, distribute, publish, prepare derivative works, and to use the software in public or private performance (collectively "use"), where such use shall be governed by the terms of the Lilium License, Version 1 or, at your option, any later version.
+>
+> A copy of the full text Lilium License, Version 1 may be obtained at TODO INSERT ADDRESS.
+> 
+> TO THE GREATEST EXTENT POSSIBLE BY LAW, THIS SOFTWARE IS PROVIDED ON AN AS IS BASIS, WITHOUT ANY WARRANTY, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. 
+
+Or may apply a modified version that specifies a range of versions which are valid to use with the software.
+
+Where the future-version Short-Form License Notice is used, any person who disseminates the software may do so under any specified version and, when distributing the software, may reproduce that Short-Form License Notice, or may instead reproduce either the Entire License Notice or Short-Form License Notice of any version allowed by the future-version notice. 
+
+#### §7 Warranty Notice
+
+Unless otherwise explicitly agreed in writing by you and the person who provided you this software, the following warranty disclaimer applies to your use of the software. If the person who provided you this software provided you with a Warranty for it, or for it combined with another product, the Warranty is between you and that person and is only on the terms for such negotiated with that person, and in no event shall the Copyright Holder or any Contributor be liable for providing that warranty, unless explicitly agreed to in writing by that particular Contributor or Copyright Holder.
+
+THIS SOFTWARE IS PROVIDED ON AN AS IS BASIS, WITHOUT ANY WARRANTY, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT.
+BY USING THIS WORK, YOU AGREE TO RELEASE THE COPYRIGHT HOLDERS AND ALL CONTRIBUTORS FROM ALL LIABILITY ARISING FROM OR IN CONNECTION WITH YOUR USE OF THIS WORK.
+
+In the event that the Jurisdiction you use this software in does not permit the waiver of the implied warranties, or does not permit such a waiver without providing an express warranty, the warranties are waived to the greatest extent permitted by law, and unless otherwise negotiated, only those implied warranties listed above that cannot be waived persist.
+
+if there are any surviving warranties, you agree that the person or persons identified below shall be solely liable for providing those warranties, to the exclusive of any other Contributor or Copyright Holder, or any other Third Party, and that, to the greatest extent permitted by law, that liability incurred by those persons shall be limited to the total value of the fee you paid to obtain a copy of this software, if any, and work for making any technical changes reasonably necessary to restore the software to a working condition that complies with the surviving implied warranties:
+
+    * If you negotiated, in writing, with a particular person or persons to either obtain an express warranty for the software, or to certify any implied warranties that apply, the person who agreed to provision such warranties to you, 
+    * If you obtained this software in exchange for a fee, the person or persons to whom the fee was paid, or
+    * Otherwise, the Copyright Holders, jointly and severally.
+
+
+
+#### §8 Application of this License to Contributions
+
+Any person who, having authority of the owner thereof to do so, intentionally submits a Contribution to This Software, unless designated otherwise in connection to a particular Contribution, agrees to allow the use of that Contribution, whether or not together with This Software, under the terms of:
+   * This License,
+   * Any Version of the Lilium License which, at the time of the Contribution, the Copyright Holder indicated in a prominent place that the software could be used in respect to This Software by, whether or not that version in particular was published at that time, or
+   * Any other Open Source Software License, as recognized by the Open Source Institute, which, at the time of the Contribution, the Copyright Holder indicated in a prominent place that the software could be used under the terms of.
+
+#### §9 Acceptance of this Agreement; Retroactive Application
+
+Where a Court of Competent Jurisdiction finds it reasonable to do so, You are presumed to implicitly agree to the terms of This License on such a day when, knowing that this license is applied to This Software, and having had opportunity to review the terms thereof, you do anything that is authorized by this agreement that would otherwise be an infringement of any Copyright, Patent, or Trademark held by a Copyright Holder or a Contributor in respect to This Software. 
+
+If, prior to the date on which you first agree to This License, you carried out any act that constitutes an infringement of Copyright, Patent, or Trademark held by a Copyright Holder or a Contributor in respect to This Software, where such act would have been authorized but for the fact you have not agreed to this license, then all such Copyright Holders and Contributors waive any claim which would arise under such infringements that are not commenced prior to the date on which you first agree to This License.
+
+#### §10 Duration of This License
+
+Except as specified in this section, or as agreed by You and the Copyright Holder separately in writing, this license is perpetual from the moment you agree to it, and may not be revoked or terminated, except that §2 may be revoked as provided therein.
+
+Where a Court of Competent Jurisdiction finds that any law or rule against perpetuities may apply to this agreement, the duration of this agreement, unless revoked under this section, shall be until the earlier of:
+* The entry of The Software into the Public Domain, or
+* 150 Years after the death of the last Copyright Holder, or Contributor.
+
+If You violate this license and recieve notice from the Copyright Holder within 90 days of the violation, or, in the case of an ongoing violation, at any point during the violation or within 90 days of the last day on which the violation occurs, then unless specified otherwise in the notice or in writing, all rights conferred upon You by this license are revoked 30 days following the notice unless, during that period:
+* You take all necessary steps to prevent future violations of this license,
+* You take all necessary and reasonable steps to cure the violation to which you are notified, and any other violation that occured or was ongoing within 90 days of the date of the notice, whether or not you have been notified of such violation, and
+* You notify the Copyright Holder within 45 days in writing of the steps you have taken to comply with this provision (Collectively "Compliance Steps").
+
+The Notice provided above may require compliance within a longer period of time to complete the Compliance Steps and for the notification of them, or may indicate any other steps the Copyright Holder may ask, and compliance of those steps within the timeframe it specifies may be sufficient to prevent revocation, but completion of the Complaince Steps shall nonetheless be sufficient.
+
+Upon reciept of a notifice of compliance, the Copyright Holder, if they believe that you have not fulfilled the Compliance Steps, shall notify you within 45 days of recieving that notice that they are revoking the license with respect to you permanently, and such revocation shall be effectively only if the Compliance Steps are not fulfilled. 
+
+Regardless of this section, failure of the Copyright Holder to notify You of a violation within the 90 day period above shall not constitute a waiver of the right to revoke the license for any other violation, or a waiver of liability for such violations, including but not limited to any liability that may arise under Copyright or Contract Law as a result of such violation.
+
+Where This License may be revoked to any person, the permissions granted under it may be restored only by written agreement of that person and the Copyright Holder, but such shall not prejudice any person who recieved This Software from that person, including who recieved it in violation of this license, or who may have recieved This Software after This License was revoked.
+
+#### §11 General Provisions
+
+Where a Court of Competent Jurisdiction finds any provision of this agreement to be illegal or unenforceable, the remainder of this agreement shall remain in force.
+
+
+## Security Considerations
+
+None
+
+## ABI Considerations
+
+None
+
+## Prior Art
+
+## Future Direction
+
+<!--
+Provide an informative explanation of any future possibilities.
+-->
+
+## References
+
+### Normative References
+
+<!--List all documents cited normatively here. 
+A Normative Reference is a reference within the main text (Normative Text section, Security Considerations, or Registry Impacts) for the meaningful content within.
+For example, if you use definitions from another specification, it would be a normative reference.
+-->
+
+### Informative References
+
+<!--Include any documents cited to provide informative context only-->

--- a/src/rfcs/0012-lilium-license.md
+++ b/src/rfcs/0012-lilium-license.md
@@ -6,7 +6,7 @@ The Lilium License is a permissive license that provides copyright, patent, and 
 
 ## Motivation
 
-Certain future design features
+The Lilium kernel, and some associated parts of the userspace, are open source software, allowing any user to freely share it, and to examine and modify it for their own use or needs, or simply as an educational activity. However, planned features, such as elf signing, could be used as a form of DRM by a third party, effectively limiting the freedoms of the end users. To avoid this, Lilium needs to adopt a permissive license that provides explicit grants around Technological Protection Measures that allow end user rights to persist even in the presence of third party, closed source software.
 
 ## Informative Explanation
 
@@ -72,7 +72,7 @@ Everyone who receives a copy of this work shall have from the Copyright Holders 
   * Their Contributions Alone, or
   * The Combination of their Contribution and the Work at the time the Contribution was actually included in the work.
 
-The above Patent License shall be revoked to a particular person or persons on such a day that the person may file, in any court worldwide, a suit against the any Copyright Holder or Copyright Holders, against any Contributor or Contributors, or against any Copyright Holder or Copyright Holders together with any Contributor or Contributors, alleging that this Work or any Contribution or combination of Contributions thereof, infringes any patent they have rights to. 
+The above Patent License shall be revoked to a particular person or persons on such a day that the person may file, in any court worldwide, a suit against the any Copyright Holder or Copyright Holders, against any Contributor or Contributors, or against any Copyright Holder or Copyright Holders together with any Contributor or Contributors, alleging that this Work or any Contribution or combination of Contributions thereof, infringes any patent they have rights to.
 
 #### §3 Limited Trademark License
 
@@ -198,6 +198,15 @@ Where This License may be revoked to any person, the permissions granted under i
 
 Where a Court of Competent Jurisdiction finds any provision of this agreement to be illegal or unenforceable, the remainder of this agreement shall remain in force.
 
+### Licensing of Software by the Lilium Project
+
+Presently, all software released by the Lilium Project is available under the MIT and Apache 2.0 License (either or license, or both, at the option of the end user). These provided permissive copyright and patent licenses to end users.
+
+Following this license, all software will additionally be licensed under the license described above, though most of it (including all existing code) will continue to also be available under the two above licenses. Which license is used remains at the option of the user.
+
+Certain parts of the software may, instead, be licensed under either just the Lilium License, or the Lilium License or the GNU General Public License version 3, at the end user's option. Which option is used will be determined at a later time. The parts licensed in this manner will be parts that can be effectively used as a Technological Protection Measure.
+
+This section does not apply to Licensing of parts of Lilium other than the software implementations of Lilium provided by the Lilium Project. In particular, it doesn't apply to this repository, or to lilium-knums. It also doesn't apply to third-party reimplementations of Lilium.
 
 ## Security Considerations
 


### PR DESCRIPTION
The Lilium License is a permissive license that provides copyright, patent, and limited trademark grants, as well as a clause about Technological Protection Measures. It is intended to comply with the Open Source License definition defined by the Open Source Institute. It is also intended to comply with the four freedoms of free software set forth by the Free Software Foundation, though it does not create a copyleft obligation like many licenses provided by the FSF.

Note: Adoption of this RFC is blocked pending legal review of the text of the license, and any changes necessary.